### PR TITLE
Support unicode search

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { mapSearchToAlfredOutput, getDomain } from './transformers'
 const spaceInfo = await fetchSpaceInfo()
 const domain = getDomain(spaceInfo)
 
-const searchResponse = await search(alfy.input)
+const searchResponse = await search(alfy.input.normalize())
 const result = mapSearchToAlfredOutput(domain, searchResponse)
 
 alfy.output(result)


### PR DESCRIPTION
## Issue
* Unicode search not supported

## Change

* Support unicode search (using normalize)
 
## Before

<img width="640" alt="Screen Shot 2020-08-23 12 46 01" src="https://user-images.githubusercontent.com/18283033/90970358-e6bb7780-e53e-11ea-8127-abd233c8a8a8.png">

## After

<img width="640" alt="Screen Shot 2020-08-23 12 44 34" src="https://user-images.githubusercontent.com/18283033/90970356-e28f5a00-e53e-11ea-81be-b8f8118d9390.png">

## Note

I think unicode searching would be useful.

